### PR TITLE
feat(collections): add support for yaml collections

### DIFF
--- a/pkg/yaml/yaml.go
+++ b/pkg/yaml/yaml.go
@@ -34,6 +34,18 @@ func convertToStringMap(m map[interface{}]interface{}) map[string]interface{} {
 		case map[interface{}]interface{}:
 			stringMap := convertToStringMap(v.(map[interface{}]interface{}))
 			newMap[k.(string)] = stringMap
+		case []interface{}:
+			var collection []interface{}
+			for _, vv := range v.([]interface{}) {
+				switch vv.(type) {
+				case map[interface{}]interface{}:
+					collection = append(collection, convertToStringMap(vv.(map[interface{}]interface{})))
+				case string:
+					collection = append(collection, fmt.Sprintf("%v", vv))
+				}
+			}
+			newMap[k.(string)] = collection
+
 		default:
 			newMap[k.(string)] = fmt.Sprintf("%v", v)
 		}

--- a/pkg/yaml/yaml_test.go
+++ b/pkg/yaml/yaml_test.go
@@ -1,13 +1,13 @@
 package yaml
 
 import (
-	"fmt"
-	"io/ioutil"
-	"os"
-	"testing"
+"fmt"
+"io/ioutil"
+"os"
+"testing"
 
-	"github.com/stretchr/testify/assert"
-	yaml "gopkg.in/yaml.v2"
+"github.com/stretchr/testify/assert"
+yaml "gopkg.in/yaml.v2"
 )
 
 func check(t *testing.T, e error) {
@@ -105,4 +105,30 @@ func TestResolver(t *testing.T) {
 	//empty url
 	project := google["primaryCredentials"].(map[string]interface{})["project"]
 	assert.Equal(t, "", project)
+}
+
+func TestResolverCollections(t *testing.T) {
+
+	fileNames := []string{
+		"collections.yml",
+	}
+
+	ymlMaps := []map[interface{}]interface{}{}
+	for _, f := range fileNames {
+		ymlMaps = append(ymlMaps, readTestFixtures(t, f))
+	}
+	envKeyPairs := map[string]string{
+		"SPINNAKER_AWS_ENABLED": "true",
+		"DEFAULT_DNS_NAME":      "mockdns.com",
+		"REDIS_HOST":            "redishost.com",
+	}
+
+	resolved, err := Resolve(ymlMaps, envKeyPairs)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, "http://localhost:8080", resolved["baseUrl"])
+	assert.Equal(t, []interface{}{map[string]interface{}{"multi_one_one":"one-one", "multi_one_two":"one-two"}, map[string]interface{}{"multi_two_one":"two-one", "multi_two_two":"two-two"}}, resolved["multiValCol"])
+	assert.Equal(t, []interface{}{"one", "two", "three"}, resolved["col"])
 }

--- a/pkg/yaml/yaml_test.go
+++ b/pkg/yaml/yaml_test.go
@@ -130,5 +130,6 @@ func TestResolverCollections(t *testing.T) {
 
 	assert.Equal(t, "http://localhost:8080", resolved["baseUrl"])
 	assert.Equal(t, []interface{}{map[string]interface{}{"multi_one_one":"one-one", "multi_one_two":"one-two"}, map[string]interface{}{"multi_two_one":"two-one", "multi_two_two":"two-two"}}, resolved["multiValCol"])
+	assert.Equal(t, []interface{}{map[string]interface{}{"multi_one_one":"one-one", "multi_one_two":"one-two"}, map[string]interface{}{"multi_two_one":"two-one", "multi_two_two":"two-two"}}, resolved["multiValColAgain"])
 	assert.Equal(t, []interface{}{"one", "two", "three"}, resolved["col"])
 }

--- a/test/collections.yml
+++ b/test/collections.yml
@@ -1,0 +1,12 @@
+baseUrl: "http://localhost:8080"
+multiValCol:
+  -
+    multi_one_one: one-one
+    multi_one_two: one-two
+  -
+    multi_two_one: two-one
+    multi_two_two: two-two
+col:
+    - one
+    - two
+    - three

--- a/test/collections.yml
+++ b/test/collections.yml
@@ -6,6 +6,11 @@ multiValCol:
   -
     multi_two_one: two-one
     multi_two_two: two-two
+multiValColAgain:
+  - multi_one_one: one-one
+    multi_one_two: one-two
+  - multi_two_one: two-one
+    multi_two_two: two-two
 col:
     - one
     - two


### PR DESCRIPTION
Adds support for yaml collections. 

```
multiValCol:
  -
    multi_one_one: one-one
    multi_one_two: one-two
  -
    multi_two_one: two-one
    multi_two_two: two-two
```
```
multiValColAgain:
  - multi_one_one: one-one
    multi_one_two: one-two
  - multi_two_one: two-one
    multi_two_two: two-two
```
```
col:
    - one
    - two
    - three
```
