### PR TITLE
feat(gcs): Support for decrypting secrets in GCS

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,74 +2,642 @@
 
 
 [[projects]]
+  digest = "1:fd319661e53f3607b8ddbded6121f8e4fe42978cb66968b20fdee68e10d10f9f"
+  name = "cloud.google.com/go"
+  packages = [
+    ".",
+    "compute/metadata",
+    "iam",
+    "internal",
+    "internal/optional",
+    "internal/trace",
+    "internal/version",
+    "storage",
+  ]
+  pruneopts = ""
+  revision = "264def2dd949cdb8a803bb9f50fa29a67b798a6a"
+  version = "v0.46.3"
+
+[[projects]]
+  digest = "1:e4b30804a381d7603b8a344009987c1ba351c26043501b23b8c7ce21f0b67474"
+  name = "github.com/BurntSushi/toml"
+  packages = ["."]
+  pruneopts = ""
+  revision = "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005"
+  version = "v0.3.1"
+
+[[projects]]
+  digest = "1:ff93b72cfe8f0ea34a6b2a5ec76061996451e8eb547e05ec1c333d1c9d17d4c4"
+  name = "github.com/aws/aws-sdk-go"
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/processcreds",
+    "aws/credentials/stscreds",
+    "aws/csm",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/ini",
+    "internal/s3err",
+    "internal/sdkio",
+    "internal/sdkmath",
+    "internal/sdkrand",
+    "internal/sdkuri",
+    "internal/shareddefaults",
+    "private/protocol",
+    "private/protocol/eventstream",
+    "private/protocol/eventstream/eventstreamapi",
+    "private/protocol/json/jsonutil",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/restxml",
+    "private/protocol/xml/xmlutil",
+    "service/s3",
+    "service/s3/s3iface",
+    "service/s3/s3manager",
+    "service/sts",
+    "service/sts/stsiface",
+  ]
+  pruneopts = ""
+  revision = "6bb638a9cf6177e3cc9748a95a2410bb26f1f426"
+  version = "v1.25.8"
+
+[[projects]]
+  digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = ""
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:31785352df956b10a0e82cc3e31bfd30785b58a433120bc8878cb66df35f9d05"
+  name = "github.com/golang/groupcache"
+  packages = ["lru"]
+  pruneopts = ""
+  revision = "404acd9df4cc9859d64fb9eed42e5c026187287a"
+
+[[projects]]
+  digest = "1:b852d2b62be24e445fcdbad9ce3015b44c207815d631230dfce3f14e7803f5bf"
+  name = "github.com/golang/protobuf"
+  packages = [
+    "proto",
+    "protoc-gen-go",
+    "protoc-gen-go/descriptor",
+    "protoc-gen-go/generator",
+    "protoc-gen-go/generator/internal/remap",
+    "protoc-gen-go/grpc",
+    "protoc-gen-go/plugin",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/timestamp",
+  ]
+  pruneopts = ""
+  revision = "6c65a5562fc06764971b7c5d05c76c75e84bdbf7"
+  version = "v1.3.2"
+
+[[projects]]
+  digest = "1:6a6322a15aa8e99bd156fbba0aae4e5d67b4bb05251d860b348a45dfdcba9cce"
+  name = "github.com/golang/snappy"
+  packages = ["."]
+  pruneopts = ""
+  revision = "2a8bb927dd31d8daada140a5d09578521ce5c36a"
+  version = "v0.0.1"
+
+[[projects]]
+  digest = "1:6120f027b9d68ef460b8731e27b0dcf2017f80605c17eb0b4cc151866ba38f6d"
+  name = "github.com/googleapis/gax-go"
+  packages = ["v2"]
+  pruneopts = ""
+  revision = "bd5b16380fd03dc758d11cef74ba2e3bc8b0e8c2"
+  version = "v2.0.5"
+
+[[projects]]
+  digest = "1:8e3bd93036b4a925fe2250d3e4f38f21cadb8ef623561cd80c3c50c114b13201"
+  name = "github.com/hashicorp/errwrap"
+  packages = ["."]
+  pruneopts = ""
+  revision = "8a6fb523712970c966eefc6b39ed2c5e74880354"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:984b627a3c838daa9f4c949ec8e6f049a7021b1156eb4db0337c3a5afe07aada"
+  name = "github.com/hashicorp/go-cleanhttp"
+  packages = ["."]
+  pruneopts = ""
+  revision = "eda1e5db218aad1db63ca4642c8906b26bcf2744"
+  version = "v0.5.1"
+
+[[projects]]
+  digest = "1:2f7a9df14614ced87f61688d9c08080e89d4a931232bf92a169e1b46b38566fe"
+  name = "github.com/hashicorp/go-hclog"
+  packages = ["."]
+  pruneopts = ""
+  revision = "5ccdce08c75b6c7b37af61159f13f6a4f5e2e928"
+  version = "v0.9.2"
+
+[[projects]]
+  digest = "1:72308fdd6d5ef61106a95be7ca72349a5565809042b6426a3cfb61d99483b824"
+  name = "github.com/hashicorp/go-multierror"
+  packages = ["."]
+  pruneopts = ""
+  revision = "886a7fbe3eb1c874d46f623bfa70af45f425b3d1"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:84050a8958e1c4a42041461000bad406e567402677dc026dd6e0342ccbeb4392"
+  name = "github.com/hashicorp/go-retryablehttp"
+  packages = ["."]
+  pruneopts = ""
+  revision = "a83ad44d6a5fc343d7c4babf601092b3c189f402"
+  version = "v0.6.2"
+
+[[projects]]
+  digest = "1:1ce74de952243566df45871a9e823f3000efac179a8a75af8b1c57c49ae89d97"
+  name = "github.com/hashicorp/go-rootcerts"
+  packages = ["."]
+  pruneopts = ""
+  revision = "df8e78a645e18d56ed7bb9ae10ffb8174ab892e2"
+  version = "v1.0.1"
+
+[[projects]]
+  digest = "1:24ee99da0190535baad44a5df2710ca2e116d615fcaaffcf3b79b476450af917"
+  name = "github.com/hashicorp/go-sockaddr"
+  packages = ["."]
+  pruneopts = ""
+  revision = "c7188e74f6acae5a989bdc959aa779f8b9f42faf"
+  version = "v1.0.2"
+
+[[projects]]
+  digest = "1:d14365c51dd1d34d5c79833ec91413bfbb166be978724f15701e17080dc06dec"
+  name = "github.com/hashicorp/hcl"
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token",
+  ]
+  pruneopts = ""
+  revision = "8cb6e5b959231cc1119e43259c4a608f9c51a241"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:da59a2fe2ebf791b35238bf69a7126b6d0e52498ff0e0fab36f7080603373b13"
+  name = "github.com/hashicorp/vault"
+  packages = [
+    "api",
+    "sdk/helper/compressutil",
+    "sdk/helper/consts",
+    "sdk/helper/hclutil",
+    "sdk/helper/jsonutil",
+    "sdk/helper/parseutil",
+    "sdk/helper/strutil",
+  ]
+  pruneopts = ""
+  revision = "c14bd9a2b1d2c20f15b9f93f5c2d487507bb8a2f"
+  version = "v1.2.3"
+
+[[projects]]
+  digest = "1:302c6eb8e669c997bec516a138b8fc496018faa1ece4c13e445a2749fbe079bb"
   name = "github.com/imdario/mergo"
   packages = ["."]
+  pruneopts = ""
   revision = "9316a62528ac99aaecb4e47eadd6dc8aa6533d58"
   version = "v0.3.5"
 
 [[projects]]
+  digest = "1:13fe471d0ed891e8544eddfeeb0471fd3c9f2015609a1c000aefdedf52a19d40"
+  name = "github.com/jmespath/go-jmespath"
+  packages = ["."]
+  pruneopts = ""
+  revision = "c2b33e84"
+
+[[projects]]
+  digest = "1:79842ff66af8c6fbebb418e3403fa3e9fde8e6c82ebffc5272a3dfeaa64c0665"
+  name = "github.com/jstemmer/go-junit-report"
+  packages = [
+    ".",
+    "formatter",
+    "parser",
+  ]
+  pruneopts = ""
+  revision = "cc1f095d5cc5eca2844f5c5ea7bb37f6b9bf6cac"
+  version = "v0.9.1"
+
+[[projects]]
+  digest = "1:6dbb0eb72090871f2e58d1e37973fe3cb8c0f45f49459398d3fc740cb30e13bd"
+  name = "github.com/mitchellh/go-homedir"
+  packages = ["."]
+  pruneopts = ""
+  revision = "af06845cf3004701891bf4fdb884bfe4920b3727"
+  version = "v1.1.0"
+
+[[projects]]
   branch = "master"
+  digest = "1:eb9117392ee8e7aa44f78e0db603f70b1050ee0ebda4bd40040befb5b218c546"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
+  pruneopts = ""
   revision = "bb74f1db0675b241733089d5a1faa5dd8b0ef57b"
 
 [[projects]]
+  digest = "1:f45cc60ba08316192e5c40ec31432fde3e9cdc23e09ced4c944123c30e7f8c22"
+  name = "github.com/pierrec/lz4"
+  packages = [
+    ".",
+    "internal/xxh32",
+  ]
+  pruneopts = ""
+  revision = "645f9b948eee34cbcc335c70999f79c29c420fbf"
+  version = "v2.3.0"
+
+[[projects]]
+  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = ""
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:4244255905cb95c3c98894d671367f84a6292608ae528936fe46ba9c86f68393"
+  name = "github.com/ryanuber/go-glob"
+  packages = ["."]
+  pruneopts = ""
+  revision = "51a8f68e6c24dc43f1e371749c89a267de4ebc53"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:8cf46b6c18a91068d446e26b67512cf16f1540b45d90b28b9533706a127f0ca6"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
+  pruneopts = ""
   revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
   version = "v1.0.5"
 
 [[projects]]
+  digest = "1:7ba2551c9a8de293bc575dbe2c0d862c52252d26f267f784547f059f512471c8"
   name = "github.com/spf13/afero"
-  packages = [".","mem"]
+  packages = [
+    ".",
+    "mem",
+  ]
+  pruneopts = ""
   revision = "787d034dfe70e44075ccc060d346146ef53270ad"
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:c587772fb8ad29ad4db67575dad25ba17a51f072ff18a22b4f0257a4d9c24f75"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
+  pruneopts = ""
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
 
 [[projects]]
+  digest = "1:1967fb934ef747bf690fcc56487a06c46bf674bd91cb3381a78a7e4d5c2e1a82"
+  name = "go.opencensus.io"
+  packages = [
+    ".",
+    "internal",
+    "internal/tagencoding",
+    "metric/metricdata",
+    "metric/metricproducer",
+    "plugin/ochttp",
+    "plugin/ochttp/propagation/b3",
+    "resource",
+    "stats",
+    "stats/internal",
+    "stats/view",
+    "tag",
+    "trace",
+    "trace/internal",
+    "trace/propagation",
+    "trace/tracestate",
+  ]
+  pruneopts = ""
+  revision = "59d1ce35d30f3c25ba762169da2a37eab6ffa041"
+  version = "v0.22.1"
+
+[[projects]]
   branch = "master"
+  digest = "1:2b051135019435c0cf95756a3ff5366b87ddc7e06e91571506c6264ce721784f"
   name = "golang.org/x/crypto"
-  packages = ["ssh/terminal"]
+  packages = [
+    "ed25519",
+    "ed25519/internal/edwards25519",
+    "pbkdf2",
+    "ssh/terminal",
+  ]
+  pruneopts = ""
   revision = "7f39a6fea4fe9364fb61e1def6a268a51b4f3a06"
 
 [[projects]]
   branch = "master"
+  digest = "1:ee68e56a9a0b7f6e2795ee803aa114e894b612040e21c86e949d86fd7d275cd8"
+  name = "golang.org/x/exp"
+  packages = [
+    "apidiff",
+    "cmd/apidiff",
+  ]
+  pruneopts = ""
+  revision = "a1355ae1e2c30eb123356c2a35c2f420652999f9"
+
+[[projects]]
+  branch = "master"
+  digest = "1:07a6b419f790dba389a58ba7ef5bb5e5281fe0b3046398b33767e3bd21c0b736"
+  name = "golang.org/x/lint"
+  packages = [
+    ".",
+    "golint",
+  ]
+  pruneopts = ""
+  revision = "16217165b5de779cb6a5e4fc81fa9c1166fda457"
+
+[[projects]]
+  branch = "master"
+  digest = "1:3b22c4b2a448ff2c35e1740c7968afd9053f065d2252726a36ff7b96bf8b4cb1"
+  name = "golang.org/x/net"
+  packages = [
+    "context",
+    "context/ctxhttp",
+    "http/httpguts",
+    "http2",
+    "http2/hpack",
+    "idna",
+    "internal/timeseries",
+    "trace",
+  ]
+  pruneopts = ""
+  revision = "72f939374954d0a1b2a1e27dcda950e2724dd5c1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:01bdbbc604dcd5afb6f66a717f69ad45e9643c72d5bc11678d44ffa5c50f9e42"
+  name = "golang.org/x/oauth2"
+  packages = [
+    ".",
+    "google",
+    "internal",
+    "jws",
+    "jwt",
+  ]
+  pruneopts = ""
+  revision = "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33"
+
+[[projects]]
+  branch = "master"
+  digest = "1:a8bbf66046a1af68dd81d9d7b12cc9da2d28491fb5632b7757751cada4664444"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows",
+  ]
+  pruneopts = ""
   revision = "fc8bd948cf46f9c7af0f07d34151ce25fe90e477"
 
 [[projects]]
+  digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
   name = "golang.org/x/text"
-  packages = ["internal/gen","internal/triegen","internal/ucd","transform","unicode/cldr","unicode/norm"]
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable",
+  ]
+  pruneopts = ""
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:1290297b5048f051e77948812e93c4f09a914d02c8fb02cf2dfdaf23d73a5805"
+  name = "golang.org/x/time"
+  packages = ["rate"]
+  pruneopts = ""
+  revision = "c4c64cad1fd0a1a8dab2523e04e61d35308e131e"
+
+[[projects]]
+  branch = "master"
+  digest = "1:e2b14bc74a8cfe2709683001b741cb22b492581c49aeacb96f5801985a84f840"
+  name = "golang.org/x/tools"
+  packages = [
+    "cmd/goimports",
+    "go/analysis",
+    "go/analysis/passes/inspect",
+    "go/ast/astutil",
+    "go/ast/inspector",
+    "go/buildutil",
+    "go/gcexportdata",
+    "go/internal/gcimporter",
+    "go/internal/packagesdriver",
+    "go/packages",
+    "go/types/objectpath",
+    "go/types/typeutil",
+    "internal/fastwalk",
+    "internal/gopathwalk",
+    "internal/imports",
+    "internal/module",
+    "internal/semver",
+  ]
+  pruneopts = ""
+  revision = "6536af71d98a5bb8f2cbd2f5e62afc2f6cc93dbb"
+
+[[projects]]
+  digest = "1:7ee924abb0b38cf29b027ec60ffe9d257e96e9dade0d01b13720a95c3301c4e4"
+  name = "google.golang.org/api"
+  packages = [
+    "googleapi",
+    "googleapi/internal/uritemplates",
+    "googleapi/transport",
+    "internal",
+    "internal/gensupport",
+    "iterator",
+    "option",
+    "storage/v1",
+    "transport/http",
+    "transport/http/internal/propagation",
+  ]
+  pruneopts = ""
+  revision = "d7605a20bfcb4659ee2ea347b1f8f5be12b8a5b7"
+  version = "v0.11.0"
+
+[[projects]]
+  digest = "1:c4404231035fad619a12f82ae3f0f8f9edc1cc7f34e7edad7a28ccac5336cc96"
+  name = "google.golang.org/appengine"
+  packages = [
+    ".",
+    "internal",
+    "internal/app_identity",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/modules",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch",
+  ]
+  pruneopts = ""
+  revision = "971852bfffca25b069c31162ae8f247a3dba083b"
+  version = "v1.6.5"
+
+[[projects]]
+  branch = "master"
+  digest = "1:650883ae9adf5fc50676136789935844a105276ab75f4a88ef7bfa0f7a47681a"
+  name = "google.golang.org/genproto"
+  packages = [
+    "googleapis/api/annotations",
+    "googleapis/iam/v1",
+    "googleapis/rpc/code",
+    "googleapis/rpc/status",
+    "googleapis/type/expr",
+  ]
+  pruneopts = ""
+  revision = "a023cd5227bd25fd1f5c5633743ff3eacc93d169"
+
+[[projects]]
+  digest = "1:30d215704e78c21ffff90aa8e86ca1a438fec2837bad082116510fe5a862af5e"
+  name = "google.golang.org/grpc"
+  packages = [
+    ".",
+    "balancer",
+    "balancer/base",
+    "balancer/roundrobin",
+    "binarylog/grpc_binarylog_v1",
+    "codes",
+    "connectivity",
+    "credentials",
+    "credentials/internal",
+    "encoding",
+    "encoding/proto",
+    "grpclog",
+    "internal",
+    "internal/backoff",
+    "internal/balancerload",
+    "internal/binarylog",
+    "internal/channelz",
+    "internal/envconfig",
+    "internal/grpcrand",
+    "internal/grpcsync",
+    "internal/syscall",
+    "internal/transport",
+    "keepalive",
+    "metadata",
+    "naming",
+    "peer",
+    "resolver",
+    "resolver/dns",
+    "resolver/passthrough",
+    "serviceconfig",
+    "stats",
+    "status",
+    "tap",
+  ]
+  pruneopts = ""
+  revision = "f6d0f9ee430895e87ef1ceb5ac8f39725bafceef"
+  version = "v1.24.0"
+
+[[projects]]
+  digest = "1:40cf02345bfa29fb217cfe0767a9416d99569d4ff21dbb1fd3378ef10682549c"
+  name = "gopkg.in/square/go-jose.v2"
+  packages = [
+    ".",
+    "cipher",
+    "json",
+    "jwt",
+  ]
+  pruneopts = ""
+  revision = "730df5f748271903322feb182be83b43ebbbe27d"
+  version = "v2.3.1"
+
+[[projects]]
+  digest = "1:f0620375dd1f6251d9973b5f2596228cc8042e887cd7f827e4220bc1ce8c30e2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = ""
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
+
+[[projects]]
+  digest = "1:afc5a2804ec9be0562c937b0c684bbaf5a9c4aef7511677b539c3806be3f4783"
+  name = "honnef.co/go/tools"
+  packages = [
+    "arg",
+    "cmd/staticcheck",
+    "config",
+    "deprecated",
+    "facts",
+    "functions",
+    "go/types/typeutil",
+    "internal/cache",
+    "internal/passes/buildssa",
+    "internal/renameio",
+    "internal/sharedcheck",
+    "lint",
+    "lint/lintdsl",
+    "lint/lintutil",
+    "lint/lintutil/format",
+    "loader",
+    "printf",
+    "simple",
+    "ssa",
+    "ssautil",
+    "staticcheck",
+    "staticcheck/vrp",
+    "stylecheck",
+    "unused",
+    "version",
+  ]
+  pruneopts = ""
+  revision = "afd67930eec2a9ed3e9b19f684d17a062285f16a"
+  version = "2019.2.3"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5c32b3c5ff772e8d1bc8000c2da027ca4e4720a4b278221bfc1f8ef5af9b4513"
+  input-imports = [
+    "cloud.google.com/go/storage",
+    "github.com/aws/aws-sdk-go/aws",
+    "github.com/aws/aws-sdk-go/aws/session",
+    "github.com/aws/aws-sdk-go/service/s3",
+    "github.com/aws/aws-sdk-go/service/s3/s3manager",
+    "github.com/hashicorp/vault/api",
+    "github.com/imdario/mergo",
+    "github.com/mitchellh/mapstructure",
+    "github.com/sirupsen/logrus",
+    "github.com/spf13/afero",
+    "github.com/stretchr/testify/assert",
+    "golang.org/x/net/context",
+    "gopkg.in/yaml.v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/secrets/gcs.go
+++ b/pkg/secrets/gcs.go
@@ -1,0 +1,76 @@
+package secrets
+
+import (
+	"cloud.google.com/go/storage"
+	"fmt"
+	"golang.org/x/net/context"
+	"io/ioutil"
+)
+
+type GcsSecret struct {
+	bucket   string
+	filepath string
+	key      string
+}
+
+type GcsDecrypter struct {
+	params map[string]string
+	ctx    context.Context
+}
+
+func NewGcsDecrypter(params map[string]string) *GcsDecrypter {
+	return &GcsDecrypter{params: params, ctx: context.Background()}
+}
+
+func (gcs *GcsDecrypter) Decrypt() (string, error) {
+	gcsSecret, err := ParseGcsSecret(gcs.params)
+	if err != nil {
+		return "", err
+	}
+	return gcsSecret.fetchSecret(gcs.ctx)
+}
+
+func ParseGcsSecret(params map[string]string) (GcsSecret, error) {
+	var gcsSecret GcsSecret
+
+	bucket, ok := params["b"]
+	if !ok {
+		return GcsSecret{}, fmt.Errorf("secret format error - 'b' for bucket is required")
+	}
+	gcsSecret.bucket = bucket
+
+	filepath, ok := params["f"]
+	if !ok {
+		return GcsSecret{}, fmt.Errorf("secret format error - 'f' for file is required")
+	}
+	gcsSecret.filepath = filepath
+
+	key, ok := params["k"]
+	if ok {
+		gcsSecret.key = key
+	}
+
+	return gcsSecret, nil
+}
+
+func (secret *GcsSecret) fetchSecret(ctx context.Context) (string, error) {
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return "", fmt.Errorf("unable to create GCS client: %s", err.Error())
+	}
+	bucket := client.Bucket(secret.bucket)
+	r, err := bucket.Object(secret.filepath).NewReader(ctx)
+	if err != nil {
+		return "", fmt.Errorf("unable to get reader for bucket: %s, file: %s, error: %v", secret.bucket, secret.filepath, err)
+	}
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		return "", fmt.Errorf("unable to download file from bucket: %s, file: %s, error: %v", secret.bucket, secret.filepath, err)
+	}
+
+	if len(secret.key) > 0 {
+		return parseSecretFile(b, secret.key)
+	}
+
+	return string(b), nil
+}

--- a/pkg/secrets/s3.go
+++ b/pkg/secrets/s3.go
@@ -6,9 +6,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
-	yamlParse "gopkg.in/yaml.v2"
-	"reflect"
-	"strings"
 )
 
 const (
@@ -97,27 +94,4 @@ func (secret *S3Secret) fetchSecret() (string, error) {
 	}
 
 	return string(contents.Bytes()), nil
-}
-
-func parseSecretFile(fileContents []byte, key string) (string, error) {
-	m := make(map[interface{}]interface{})
-	if err := yamlParse.Unmarshal(fileContents, &m); err != nil {
-		return "", err
-	}
-
-	for _, yamlKey := range strings.Split(key, ".") {
-		switch s := m[yamlKey].(type) {
-		case map[interface{}]interface{}:
-			m = s
-		case string:
-			return s, nil
-		case nil:
-			return "", fmt.Errorf("error parsing secret file: couldn't find key %q in yaml", key)
-		default:
-			return "", fmt.Errorf("error parsing secret file: unknown type %q with value %q",
-				reflect.TypeOf(s), s)
-		}
-	}
-
-	return "", fmt.Errorf("error parsing secret file for key %q", key)
 }

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -53,11 +53,11 @@ func TestParseS3Secret(t *testing.T) {
 		shouldError bool
 	}{
 		{
-			map[string]string {
-				"encrypted":"s3",
-				"r":"region",
-				"b":"bucket",
-				"f":"file",
+			map[string]string{
+				"encrypted": "s3",
+				"r":         "region",
+				"b":         "bucket",
+				"f":         "file",
 			},
 			S3Secret{
 				region:   "region",
@@ -67,12 +67,12 @@ func TestParseS3Secret(t *testing.T) {
 			false,
 		},
 		{
-			map[string]string {
-				"encrypted":"s3",
-				"r":"region",
-				"b":"bucket",
-				"f":"file",
-				"k":"key",
+			map[string]string{
+				"encrypted": "s3",
+				"r":         "region",
+				"b":         "bucket",
+				"f":         "file",
+				"k":         "key",
 			},
 			S3Secret{
 				region:   "region",
@@ -83,28 +83,28 @@ func TestParseS3Secret(t *testing.T) {
 			false,
 		},
 		{
-			map[string]string {
-				"encrypted":"s3",
-				"b":"bucket",
-				"f":"file",
+			map[string]string{
+				"encrypted": "s3",
+				"b":         "bucket",
+				"f":         "file",
 			},
 			S3Secret{},
 			true,
 		},
 		{
-			map[string]string {
-				"encrypted":"s3",
-				"r":"region",
-				"f":"file",
+			map[string]string{
+				"encrypted": "s3",
+				"r":         "region",
+				"f":         "file",
 			},
 			S3Secret{},
 			true,
 		},
 		{
-			map[string]string {
-				"encrypted":"s3",
-				"r":"region",
-				"b":"bucket",
+			map[string]string{
+				"encrypted": "s3",
+				"r":         "region",
+				"b":         "bucket",
 			},
 			S3Secret{},
 			true,
@@ -121,6 +121,58 @@ func TestParseS3Secret(t *testing.T) {
 	}
 }
 
+func TestParseGcsSecret(t *testing.T) {
+	cases := []struct {
+		params      map[string]string
+		expected    GcsSecret
+		shouldError bool
+	}{
+		{
+			map[string]string{
+				"encrypted": "gcs",
+				"b":         "bucket",
+				"f":         "file",
+			},
+			GcsSecret{
+				bucket:   "bucket",
+				filepath: "file",
+			},
+			false,
+		},
+		{
+			map[string]string{
+				"encrypted": "gcs",
+				"b":         "bucket",
+				"f":         "file",
+				"k":         "key",
+			},
+			GcsSecret{
+				bucket:   "bucket",
+				filepath: "file",
+				key:      "key",
+			},
+			false,
+		},
+		{
+			map[string]string{
+				"encrypted": "gcs",
+				"b":         "bucket",
+			},
+			GcsSecret{},
+			true,
+		},
+	}
+
+	for _, c := range cases {
+		gcsSecret, err := ParseGcsSecret(c.params)
+		didError := (err != nil)
+		if didError != c.shouldError || gcsSecret != c.expected {
+			t.Errorf("for parseGcsEncryptedSecret(%s) -- expected %s with error=='%t' but got %s with error=='%t'",
+				c.params, c.expected, c.shouldError, gcsSecret, didError)
+		}
+	}
+}
+
 func TestDecrypter(t *testing.T) {
 	cases := []struct {
 		secretConfig string
@@ -129,6 +181,10 @@ func TestDecrypter(t *testing.T) {
 		{
 			"encrypted:s3!b:bucket",
 			&S3Decrypter{},
+		},
+		{
+			"encrypted:gcs!b:bucket",
+			&GcsDecrypter{},
 		},
 		{
 			"encrypted:vault!e:engine",
@@ -165,7 +221,7 @@ func TestNoVaultConfig(t *testing.T) {
 	decrypter := NewDecrypter("encrypted:vault!e:secret!n:test-secret!k:foo")
 	_, err := decrypter.Decrypt()
 	expectedError := "configuration not found"
-	if err == nil || !strings.Contains(err.Error(), expectedError)   {
+	if err == nil || !strings.Contains(err.Error(), expectedError) {
 		t.Errorf("attempting to Decrypt() without vault configured, expected error with %q but got: %q", expectedError, err)
 	}
 }
@@ -178,57 +234,57 @@ func TestParseVaultSecret(t *testing.T) {
 	}{
 		{
 			map[string]string{
-				"encrypted":"vault",
-				"e":"engine",
-				"n":"path",
-				"k":"key",
+				"encrypted": "vault",
+				"e":         "engine",
+				"n":         "path",
+				"k":         "key",
 			},
 			VaultSecret{
-				engine:   "engine",
+				engine: "engine",
 				path:   "path",
-				key:      "key",
+				key:    "key",
 			},
 			false,
 		},
 		{
 			map[string]string{
-				"encrypted":"vault",
-				"e":"engine",
-				"n":"path",
-				"k":"key",
-				"b":"true",
+				"encrypted": "vault",
+				"e":         "engine",
+				"n":         "path",
+				"k":         "key",
+				"b":         "true",
 			},
 			VaultSecret{
-				engine:   "engine",
-				path:   "path",
+				engine:        "engine",
+				path:          "path",
 				base64Encoded: "true",
-				key:      "key",
+				key:           "key",
 			},
 			false,
 		},
 		{
 			map[string]string{
-				"encrypted":"vault",
-				"n":"path",
-				"k":"key",
+				"encrypted": "vault",
+				"n":         "path",
+				"k":         "key",
 			},
 			VaultSecret{},
 			true,
 		},
 		{
 			map[string]string{
-				"encrypted":"vault",
-				"e":"engine",
-				"k":"key",
+				"encrypted": "vault",
+				"e":         "engine",
+				"k":         "key",
 			},
 			VaultSecret{},
 			true,
 		},
 		{
 			map[string]string{
-				"encrypted":"vault",
-				"e":"engine",
-				"n":"path",
+				"encrypted": "vault",
+				"e":         "engine",
+				"n":         "path",
 			},
 			VaultSecret{},
 			true,


### PR DESCRIPTION
Added support for decrypting GCS secrets. Moved function for parsing yams and extracting keys out of `s3.go` and into `secrets.go`.