### PR TITLE
feat(tls): (m)TLS support via common ssl parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 sudo: false
 go:
-  - 1.12
   - 1.13
   - master
 before_install:

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -4,7 +4,7 @@ import "fmt"
 
 type ServerConfig struct {
 	Host string `yaml:"host"`
-	Port int32  `yaml:"port"`
+	Port uint32 `yaml:"port"`
 	Ssl  Ssl    `yaml:"ssl"`
 }
 

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -1,0 +1,44 @@
+package server
+
+import "fmt"
+
+type ServerConfig struct {
+	Host string `yaml:"host"`
+	Port int32  `yaml:"port"`
+	Ssl  Ssl    `yaml:"ssl"`
+}
+
+func (s *ServerConfig) GetAddr() string {
+	return fmt.Sprintf("%s:%d", s.Host, s.Port)
+}
+
+type ClientAuthType string
+
+const (
+	// No mTLS
+	ClientAuthNone ClientAuthType = "none"
+	// Client cert verified if provided
+	ClientAuthWant ClientAuthType = "want"
+	// Client cert required and verified
+	ClientAuthNeed ClientAuthType = "need"
+	// Any client cert will do
+	ClientAuthAny ClientAuthType = "any"
+	// Request client cert
+	ClientAuthRequest ClientAuthType = "request"
+)
+
+type Ssl struct {
+	// Enable SSL
+	Enabled bool `yaml:"enabled"`
+	// Certificate file, can be just a PEM of cert + key or just the cert in which case you'll also need
+	// to provide the key file
+	CertFile string `yaml:"certFile"`
+	// Key file if the cert file doesn't provide it
+	KeyFile string `yaml:"keyFile"`
+	// Key password if the key is encrypted
+	KeyPassword string `yaml:"keyFilePassword"`
+	// when using mTLS, CA PEM. If not provided, it will default to the certificate of the server as a CA
+	CAcertFile string `yaml:"cacertFile"`
+	// Client auth requested (none, want, need, any, request)
+	ClientAuth ClientAuthType `yaml:"clientAuth"`
+}

--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -1,0 +1,20 @@
+package server
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetAddr(t *testing.T) {
+	c := ServerConfig{
+		Host: "",
+		Port: 3000,
+	}
+	assert.Equal(t, ":3000", c.GetAddr())
+
+	c = ServerConfig{
+		Host: "0.0.0.0",
+		Port: 3000,
+	}
+	assert.Equal(t, "0.0.0.0:3000", c.GetAddr())
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,0 +1,215 @@
+package server
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"github.com/armory/go-yaml-tools/pkg/secrets"
+	"io/ioutil"
+	"net/http"
+	"os"
+)
+
+type Server struct {
+	config *ServerConfig
+	server *http.Server
+}
+
+func NewServer(config *ServerConfig) *Server {
+	return &Server{
+		config: config,
+	}
+}
+
+// Start starts the server on the configured port
+func (s *Server) Start(router http.Handler) error {
+	if !s.config.Ssl.Enabled {
+		return s.startHttp(router)
+	}
+	return s.startTls(router)
+}
+
+func (s *Server) Shutdown(ctx context.Context) error {
+	return s.server.Shutdown(ctx)
+}
+
+func (s *Server) startHttp(router http.Handler) error {
+	s.server = &http.Server{
+		Addr:    s.config.GetAddr(),
+		Handler: router,
+	}
+	return s.server.ListenAndServe()
+}
+
+func (s *Server) startTls(router http.Handler) error {
+	tlsConfig, err := s.tlsConfig()
+	if err != nil {
+		return err
+	}
+
+	certMode := s.getClientCertMode()
+	if certMode != tls.NoClientCert {
+		// With mTLS, we'll parse our PEM to discover CAs with which to validate client certificates
+		caFile := s.config.Ssl.CAcertFile
+		if caFile == "" {
+			// Fall back to cert file - could be a combined PEM (e.g. self signed)
+			caFile = s.config.Ssl.CertFile
+		} else if err := checkFileReadable(caFile); err != nil {
+			return fmt.Errorf("error with certificate authority file %s: %w", caFile, err)
+		}
+
+		// Create a CA certificate pool and add our server certificate
+		caCert, err := ioutil.ReadFile(caFile)
+		if err != nil {
+			return err
+		}
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
+		tlsConfig.ClientCAs = caCertPool
+		tlsConfig.ClientAuth = certMode
+	}
+
+	// Discover the server name based on given certificates
+	tlsConfig.BuildNameToCertificate()
+
+	// Create a Server instance to listen on port 8443 with the TLS config
+	server := &http.Server{
+		Addr:      s.config.GetAddr(),
+		Handler:   router,
+		TLSConfig: tlsConfig,
+	}
+
+	// Listen to HTTPS connections with the server certificate and wait
+	return server.ListenAndServeTLS("", "")
+}
+
+func (s *Server) getClientCertMode() tls.ClientAuthType {
+	switch s.config.Ssl.ClientAuth {
+	case ClientAuthWant:
+		return tls.VerifyClientCertIfGiven
+	case ClientAuthNeed:
+		return tls.RequireAndVerifyClientCert
+	case ClientAuthAny:
+		return tls.RequireAnyClientCert
+	case ClientAuthRequest:
+		return tls.RequestClientCert
+	default:
+		return tls.NoClientCert
+	}
+}
+
+func checkFileReadable(filename string) error {
+	if secrets.IsEncryptedSecret(filename) {
+		d, err := secrets.NewDecrypter(context.TODO(), filename)
+		if err != nil {
+			return err
+		}
+		filename, err = d.Decrypt()
+		if err != nil {
+			return err
+		}
+	}
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return err
+	}
+	m := info.Mode()
+	if m&(1<<2) != 0 {
+		return nil
+	}
+	return fmt.Errorf("file %s is not readable", filename)
+}
+
+// tlsConfig prepares the TLS config of the server
+// certFile must contain the certificate of the server. It can also contain the private key (optionally encrypted)
+// keyFile is needed if the certFile doesn't contain the private key. It can also be encrypted.
+func (s *Server) tlsConfig() (*tls.Config, error) {
+	if err := checkFileReadable(s.config.Ssl.CertFile); err != nil {
+		return nil, fmt.Errorf("error with certificate file %s: %w", s.config.Ssl.CertFile, err)
+	}
+
+	b, err := ioutil.ReadFile(s.config.Ssl.CertFile)
+	if err != nil {
+		return nil, err
+	}
+
+	pemBlocks, pkey, err := s.readAndDecryptPEM(b)
+
+	// If private key not in the cert file, we look for it in the key file
+	if pkey == nil {
+		pkey, err = s.getPrivateKey()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	c, _ := tls.X509KeyPair(pem.EncodeToMemory(pemBlocks[0]), pkey)
+
+	return &tls.Config{
+		Certificates:             []tls.Certificate{c},
+		PreferServerCipherSuites: true,
+		MinVersion:               tls.VersionTLS12,
+	}, nil
+}
+
+// getPrivateKey attempts to load and decrypt the private key if needed
+func (s *Server) getPrivateKey() ([]byte, error) {
+	if err := checkFileReadable(s.config.Ssl.KeyFile); err != nil {
+		return nil, fmt.Errorf("error with key file %s: %w", s.config.Ssl.KeyFile, err)
+	}
+	b, err := ioutil.ReadFile(s.config.Ssl.KeyFile)
+	if err != nil {
+		return nil, err
+	}
+	_, pkey, err := s.readAndDecryptPEM(b)
+	return pkey, err
+}
+
+// readAndDecryptPEM reads PEM data and attempts to decrypt if a private key is found encrypted
+// using ssl.keyPassword provided in the config
+func (s *Server) readAndDecryptPEM(data []byte) ([]*pem.Block, []byte, error) {
+	var pemBlocks []*pem.Block
+	var v *pem.Block
+	var pkey []byte
+
+	for {
+		v, data = pem.Decode(data)
+		if v == nil {
+			break
+		}
+		if v.Type == "RSA PRIVATE KEY" {
+			if x509.IsEncryptedPEMBlock(v) {
+				pass, err := s.getKeyPassword()
+				if err != nil {
+					return nil, nil, err
+				}
+				pkey, _ = x509.DecryptPEMBlock(v, []byte(pass))
+				pkey = pem.EncodeToMemory(&pem.Block{
+					Type:  v.Type,
+					Bytes: pkey,
+				})
+			} else {
+				pkey = pem.EncodeToMemory(v)
+			}
+		} else {
+			pemBlocks = append(pemBlocks, v)
+		}
+	}
+	return pemBlocks, pkey, nil
+}
+
+func (s *Server) getKeyPassword() (string, error) {
+	if secrets.IsEncryptedSecret(s.config.Ssl.KeyPassword) {
+		d, err := secrets.NewDecrypter(context.TODO(), s.config.Ssl.KeyPassword)
+		if err != nil {
+			return "", err
+		}
+		return d.Decrypt()
+	}
+	if s.config.Ssl.KeyPassword == "" {
+		return "", fmt.Errorf("encrypted pem found but no password provided")
+	}
+	return s.config.Ssl.KeyPassword, nil
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"github.com/armory/go-yaml-tools/pkg/secrets"
 	"io/ioutil"
@@ -105,6 +106,9 @@ func checkFileReadable(filename string) error {
 		d, err := secrets.NewDecrypter(context.TODO(), filename)
 		if err != nil {
 			return err
+		}
+		if !d.IsFile() {
+			return errors.New("no file referenced, use encryptedFile")
 		}
 		filename, err = d.Decrypt()
 		if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -76,14 +76,14 @@ func (s *Server) startTls(router http.Handler) error {
 	tlsConfig.BuildNameToCertificate()
 
 	// Create a Server instance to listen on port 8443 with the TLS config
-	server := &http.Server{
+	s.server = &http.Server{
 		Addr:      s.config.GetAddr(),
 		Handler:   router,
 		TLSConfig: tlsConfig,
 	}
 
 	// Listen to HTTPS connections with the server certificate and wait
-	return server.ListenAndServeTLS("", "")
+	return s.server.ListenAndServeTLS("", "")
 }
 
 func (s *Server) getClientCertMode() tls.ClientAuthType {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestEncryptedKey(t *testing.T) {
+	cases := []struct {
+		name        string
+		password    string
+		errExpected bool
+		expected    string
+	}{
+		{
+			name:        "not encrypted",
+			password:    "asdf1234",
+			errExpected: false,
+			expected:    "asdf1234",
+		},
+		{
+			name:        "encrypted noop",
+			password:    "encrypted:noop!asdf1234",
+			errExpected: false,
+			expected:    "asdf1234",
+		},
+		{
+			name:        "encrypted fail",
+			password:    "encrypted:doesnotexist!asdf1234",
+			errExpected: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := Server{
+				config: &ServerConfig{
+					Ssl: Ssl{
+						KeyPassword: c.password,
+					},
+				},
+			}
+			p, err := s.getKeyPassword()
+			if assert.Equal(t, c.errExpected, err != nil) {
+				assert.Equal(t, c.expected, p)
+			}
+		})
+	}
+}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,7 +1,10 @@
 package server
 
 import (
+	"fmt"
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"os"
 	"testing"
 )
 
@@ -46,4 +49,31 @@ func TestEncryptedKey(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFileReadable(t *testing.T) {
+	err := checkFileExists(fmt.Sprintf("encrypted:noop!asdf"))
+	if !assert.NotNil(t, err) {
+		return
+	}
+	assert.Equal(t, "no file referenced, use encryptedFile", err.Error())
+
+	err = checkFileExists(fmt.Sprintf("encryptedFile:noop!asdf"))
+	if !assert.Nil(t, err) {
+		return
+	}
+
+	// set up a non empty temp file
+	tmpfile, err := ioutil.TempFile("", "cert")
+	if !assert.Nil(t, err) {
+		return
+	}
+	defer tmpfile.Close()
+
+	// File should be readable
+	assert.Nil(t, checkFileExists(tmpfile.Name()))
+
+	// Remove the file
+	os.Remove(tmpfile.Name())
+	assert.NotNil(t, checkFileExists(tmpfile.Name()))
 }


### PR DESCRIPTION
To use, pass a handler and a config. To enable SSL, pass `config.ssl.enabled = true`.
- `certFile`: always required, x509 format. Can be PEM of cert + private key or just the cert.
- `keyFile`: the private key if not provided with the cert.
- `keyPassword`: password to the private key if key is encrypted
- `clientAuth`: client auth requested (none, want, need, any, request)
- `cacertFile`: CA PEM. If not provided, defaults to the certificate as a CA.

certFile, keyFile, cacertFile, and keyPassword can be stored as secrets.