### PR TITLE
feature(secrets): update yaml subValues func to also support substituting secrets in yaml, to align with kork-secrets

### DIFF
--- a/pkg/yaml/yaml.go
+++ b/pkg/yaml/yaml.go
@@ -1,7 +1,9 @@
 package yaml
 
 import (
+	"context"
 	"fmt"
+	"github.com/armory/go-yaml-tools/pkg/secrets"
 	"regexp"
 	"strings"
 
@@ -23,7 +25,12 @@ func Resolve(ymlTemplates []map[interface{}]interface{}, envKeyPairs map[string]
 	}
 	stringMap := convertToStringMap(mergedMap)
 
-	subValues(stringMap, stringMap, envKeyPairs)
+	err := subValues(stringMap, stringMap, envKeyPairs)
+
+	if err != nil {
+		return nil, err
+	}
+
 	return stringMap, nil
 }
 
@@ -53,7 +60,7 @@ func convertToStringMap(m map[interface{}]interface{}) map[string]interface{} {
 	return newMap
 }
 
-func subValues(fullMap map[string]interface{}, subMap map[string]interface{}, env map[string]string) {
+func subValues(fullMap map[string]interface{}, subMap map[string]interface{}, env map[string]string) error {
 	//responsible for finding all variables that need to be substituted
 	keepResolving := true
 	loops := 0
@@ -63,9 +70,20 @@ func subValues(fullMap map[string]interface{}, subMap map[string]interface{}, en
 		for k, value := range subMap {
 			switch value.(type) {
 			case map[string]interface{}:
-				subValues(fullMap, value.(map[string]interface{}), env)
+				return subValues(fullMap, value.(map[string]interface{}), env)
 			case string:
 				valStr := value.(string)
+
+				secret, wasSecret, err := resolveSecret(valStr)
+				if err != nil {
+					return err
+				}
+
+				if wasSecret {
+					subMap[k] = secret
+					continue
+				}
+
 				keys := re.FindAllStringSubmatch(valStr, -1)
 				for _, keyToSub := range keys {
 					resolvedValue := resolveSubs(fullMap, keyToSub[1], env)
@@ -74,6 +92,25 @@ func subValues(fullMap map[string]interface{}, subMap map[string]interface{}, en
 			}
 		}
 	}
+	return nil
+}
+
+func resolveSecret(valStr string) (string, bool, error) {
+	// if the value is a secret resolve it
+	if secrets.IsEncryptedSecret(valStr) {
+		d, err := secrets.NewDecrypter(context.TODO(), valStr)
+		if err != nil {
+			return "", true, err
+		}
+
+		secret, err := d.Decrypt()
+		if err != nil {
+			return "", true, err
+		}
+
+		return secret, true, nil
+	}
+	return valStr, false, nil
 }
 
 func resolveSubs(m map[string]interface{}, keyToSub string, env map[string]string) string {


### PR DESCRIPTION
I noticed when I went to UAT AWS Secrets Manager support that this library didn't work like kork-secrets did when my UAT test program didn't work.

With this PR you can do secret substitution in the yaml config just like kork-secrets

ex: from my user acceptance test

config.yaml
```yaml
pathToBinaryFile: encryptedFile:secrets-manager!r:us-west-2!s:justins-demo-local-cerberus-pkcs
pathToPlaintextFile: encryptedFile:secrets-manager!r:us-west-2!s:justins_ssh_key_demo
secretThatWasAKeyInJsonObject: encrypted:secrets-manager!r:us-west-2!s:justins-demo-local-cerberus-secrets!k:pkcs-password
subKey:
  plaintextSecretValue: encrypted:secrets-manager!r:us-west-2!s:test
  foo: bar
```

user_acceptence_test_of_aws_sm_secrets.go
```go
package main

import (
	"fmt"
	"github.com/armory/go-yaml-tools/pkg/spring"
)

func main() {
	fmt.Println("Preparing to load secrets")

	config := []string{"config"}

	props, err := spring.LoadProperties(config, "/Users/fieldju/dev/scratch/go-yaml-tools-uat/src", []string{"SPRING_PROFILES_ACTIVE=local"})

	if err != nil {
		panic(err)
	}

	fmt.Println(props)

	fmt.Println("Fin")
}

```

![image](https://user-images.githubusercontent.com/711726/74992378-d0502a00-53fc-11ea-936f-79a807390094.png)
