### PR TITLE
feature(secrets): update yaml subValues func to also support substituting secrets in yaml, to allign with kork-secrets

### DIFF
--- a/pkg/yaml/yaml_test.go
+++ b/pkg/yaml/yaml_test.go
@@ -102,6 +102,10 @@ func TestResolver(t *testing.T) {
 	fiatURL := services["fiat"].(map[string]interface{})["baseUrl"]
 	assert.Equal(t, "http://mockdns.com:7003", fiatURL)
 
+	//secret resolve
+	echoSlackApiKey := services["echo"].(map[string]interface{})["slackApiKey"]
+	assert.Equal(t, "mynotsosecretstring", echoSlackApiKey)
+
 	//empty url
 	project := google["primaryCredentials"].(map[string]interface{})["project"]
 	assert.Equal(t, "", project)

--- a/test/spinnaker-armory.yml
+++ b/test/spinnaker-armory.yml
@@ -8,6 +8,7 @@ services:
 
   echo:
     host: ${DEFAULT_DNS_NAME:echo}
+    slackApiKey: encrypted:noop!mynotsosecretstring
 
   deck:
     gateUrl: ${API_HOST:service.default.host}


### PR DESCRIPTION
I noticed when I went to UAT AWS Secrets Manager support that this library didn't work like kork-secrets did when my UAT test program didn't work.

With this PR you can do secret substitution in the yaml config just like kork-secrets

ex: from my user acceptance test

config.yaml
```yaml
pathToBinaryFile: encryptedFile:secrets-manager!r:us-west-2!s:justins-demo-local-cerberus-pkcs
pathToPlaintextFile: encryptedFile:secrets-manager!r:us-west-2!s:justins_ssh_key_demo
secretThatWasAKeyInJsonObject: encrypted:secrets-manager!r:us-west-2!s:justins-demo-local-cerberus-secrets!k:pkcs-password
subKey:
  plaintextSecretValue: encrypted:secrets-manager!r:us-west-2!s:test
  foo: bar
```

user_acceptence_test_of_aws_sm_secrets.go
```go
package main

import (
	"fmt"
	"github.com/armory/go-yaml-tools/pkg/spring"
)

func main() {
	fmt.Println("Preparing to load secrets")

	config := []string{"config"}

	props, err := spring.LoadProperties(config, "/Users/fieldju/dev/scratch/go-yaml-tools-uat/src", []string{"SPRING_PROFILES_ACTIVE=local"})

	if err != nil {
		panic(err)
	}

	fmt.Println(props)

	fmt.Println("Fin")
}

```

![image](https://user-images.githubusercontent.com/711726/74992378-d0502a00-53fc-11ea-936f-79a807390094.png)
