### PR TITLE
fix(secrets): make compatible with lists in configs

### DIFF
--- a/pkg/yaml/yaml.go
+++ b/pkg/yaml/yaml.go
@@ -3,9 +3,10 @@ package yaml
 import (
 	"context"
 	"fmt"
-	"github.com/armory/go-yaml-tools/pkg/secrets"
 	"regexp"
 	"strings"
+
+	"github.com/armory/go-yaml-tools/pkg/secrets"
 
 	"github.com/imdario/mergo"
 	log "github.com/sirupsen/logrus"
@@ -71,6 +72,15 @@ func subValues(fullMap map[string]interface{}, subMap map[string]interface{}, en
 			switch value.(type) {
 			case map[string]interface{}:
 				err := subValues(fullMap, value.(map[string]interface{}), env)
+				if err != nil {
+					return err
+				}
+			case []interface{}:
+				sliceMap := make(map[string]interface{})
+				for i := 0; i < len(value.([]interface{})); i++ {
+					sliceMap[string(i)] = value.([]interface{})[i]
+				}
+				err := subValues(fullMap, sliceMap, env)
 				if err != nil {
 					return err
 				}

--- a/pkg/yaml/yaml_test.go
+++ b/pkg/yaml/yaml_test.go
@@ -1,13 +1,13 @@
 package yaml
 
 import (
-"fmt"
-"io/ioutil"
-"os"
-"testing"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
 
-"github.com/stretchr/testify/assert"
-yaml "gopkg.in/yaml.v2"
+	"github.com/stretchr/testify/assert"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func check(t *testing.T, e error) {
@@ -105,6 +105,8 @@ func TestResolver(t *testing.T) {
 	//secret resolve
 	echoSlackApiKey := services["echo"].(map[string]interface{})["slackApiKey"]
 	assert.Equal(t, "mynotsosecretstring", echoSlackApiKey)
+	terraformerProfilesSSHKey := services["terraformer"].(map[string]interface{})["profiles"].([]interface{})[0].(map[string]interface{})["variables"].([]interface{})[0].(map[string]interface{})["options"].(map[string]interface{})["sshKeyContents"]
+	assert.Equal(t, "mynotsosecretsshstring", terraformerProfilesSSHKey)
 
 	//empty url
 	project := google["primaryCredentials"].(map[string]interface{})["project"]
@@ -133,7 +135,7 @@ func TestResolverCollections(t *testing.T) {
 	}
 
 	assert.Equal(t, "http://localhost:8080", resolved["baseUrl"])
-	assert.Equal(t, []interface{}{map[string]interface{}{"multi_one_one":"one-one", "multi_one_two":"one-two"}, map[string]interface{}{"multi_two_one":"two-one", "multi_two_two":"two-two"}}, resolved["multiValCol"])
-	assert.Equal(t, []interface{}{map[string]interface{}{"multi_one_one":"one-one", "multi_one_two":"one-two"}, map[string]interface{}{"multi_two_one":"two-one", "multi_two_two":"two-two"}}, resolved["multiValColAgain"])
+	assert.Equal(t, []interface{}{map[string]interface{}{"multi_one_one": "one-one", "multi_one_two": "one-two"}, map[string]interface{}{"multi_two_one": "two-one", "multi_two_two": "two-two"}}, resolved["multiValCol"])
+	assert.Equal(t, []interface{}{map[string]interface{}{"multi_one_one": "one-one", "multi_one_two": "one-two"}, map[string]interface{}{"multi_two_one": "two-one", "multi_two_two": "two-two"}}, resolved["multiValColAgain"])
 	assert.Equal(t, []interface{}{"one", "two", "three"}, resolved["col"])
 }

--- a/test/spinnaker-armory.yml
+++ b/test/spinnaker-armory.yml
@@ -41,6 +41,14 @@ services:
     port: 6379
     connection: redis://${services.redis.host}:${services.redis.port}
 
+  terraformer:
+    profiles:
+      - name: default
+        variables:
+          - kind: git-ssh
+            options:
+              sshKeyContents: encrypted:noop!mynotsosecretsshstring
+
 providers:
   aws:
     enabled: ${SPINNAKER_AWS_ENABLED:true}


### PR DESCRIPTION
Previously if you had a list element in your config that contained secrets then go-yaml-tools would fail to render them. This PR adds new functionality so that a list inside a config can be traversed just like a nested map and enclosed secrets will be correctly resolved.