### PR TITLE
fix(secrets): register vault config before attempting decryption

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,38 @@
+on: [push, pull_request]
+
+name: Build
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+          - "1.13"
+          - "1.14"
+    name: Go ${{ matrix.go }} build
+    steps:
+      - name: Setup go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Cache Build Dependencies  # Speeds up subsquent builds
+        uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: go-${{ hashFiles('**/go.sum') }}
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Get Dependencies
+        run: go mod download
+
+      - name: Test
+        run: go test -v -mod=vendor -race -covermode atomic -coverprofile=profile.cov ./...
+
+      - name: Send Coverage
+        uses: shogo82148/actions-goveralls@v1
+        with:
+          path-to-profile: profile.cov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: go
-sudo: false
-go:
-  - 1.13
-  - master
-before_install:
-  - go get github.com/mattn/goveralls
-script:
-  - $GOPATH/bin/goveralls -service=travis-ci

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -253,8 +253,10 @@ func TestDecrypter(t *testing.T) {
 func TestNoSecret(t *testing.T) {
 	notASecret := "notASecret"
 	eng, err := NewDecrypter(context.TODO(), notASecret)
-	assert.Nil(t, eng)
 	assert.Nil(t, err)
+
+	unchanged, _ := eng.Decrypt()
+	assert.Equal(t, notASecret, unchanged)
 }
 
 func TestNoVaultConfig(t *testing.T) {

--- a/pkg/secrets/vault.go
+++ b/pkg/secrets/vault.go
@@ -3,6 +3,7 @@ package secrets
 import (
 	"context"
 	"fmt"
+	"github.com/mitchellh/mapstructure"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -240,4 +241,21 @@ func (decrypter *VaultDecrypter) fetchSecret() (string, error) {
 	}
 
 	return "", nil
+}
+
+func DecodeVaultConfig(vaultYaml map[interface{}]interface{}) (*VaultConfig, error) {
+	var cfg VaultConfig
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result:           &cfg,
+		WeaklyTypedInput: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := decoder.Decode(vaultYaml); err != nil {
+		return nil, err
+	}
+
+	return &cfg, nil
 }


### PR DESCRIPTION
We need information in the Vault config block in order to know how to decrypt secrets, therefore the config needs to be "registered" before any secrets are decrypted. 

A while back, we added the ability to decrypt secrets in any field in a config file, but this caused a bug for Vault secrets, since it's now trying to decrypt before it knows anything about the Vault config block.

This fix extracts the Vault config block from the map of spinnaker config values and registers it before it iterates through the configs and tries to decrypt secrets.