### PR TITLE
fix(secretManager): fix parsing of secrets

### DIFF
--- a/pkg/secrets/aws_secrets_manager.go
+++ b/pkg/secrets/aws_secrets_manager.go
@@ -73,7 +73,7 @@ func (a *AwsSecretsManagerDecrypter) parse(params string) error {
 		return fmt.Errorf(GenericMalformedKeyError)
 	}
 	for _, entry := range entries {
-		kvPair := strings.Split(entry, ":")
+		kvPair := strings.SplitN(entry, ":", 2)
 		if len(kvPair) != 2 {
 			return fmt.Errorf(GenericMalformedKeyError)
 		}

--- a/pkg/secrets/aws_secrets_manager_test.go
+++ b/pkg/secrets/aws_secrets_manager_test.go
@@ -87,6 +87,12 @@ func TestNewAwsSecretsManagerDecrypter(t *testing.T) {
 			expectedError: "",
 			isFile: false,
 		},
+		{
+			name: "secret references full secret ARN",
+			params: "r:some-region!s:my:secret/path/some-secret!k:some-key",
+			expectedError: "",
+			isFile: false,
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
fix parsing of secret refs that use the full ARN to reference a secret.
involves splitting on : but returning only 2 pieces rather than all
pieces.