### PR TITLE
fix(vault): capture more responses that warrant retrying at KV v2 path

### DIFF
--- a/pkg/secrets/vault.go
+++ b/pkg/secrets/vault.go
@@ -97,14 +97,6 @@ func (u UserPassTokenFetcher) fetchToken(client VaultClient) (string, error) {
 	return secret.Auth.ClientToken, nil
 }
 
-func handleLoginErrors(err error) (string, error) {
-	if _, ok := err.(*json.SyntaxError); ok {
-		// some connection errors aren't properly caught, and the vault client tries to parse <nil>
-		return "", fmt.Errorf("error fetching secret from vault - check connection to the server")
-	}
-	return "", fmt.Errorf("error logging into vault: %s", err)
-}
-
 type KubernetesServiceAccountTokenFetcher struct {
 	role string
 	path string
@@ -132,6 +124,14 @@ func (k KubernetesServiceAccountTokenFetcher) fetchToken(client VaultClient) (st
 	}
 
 	return secret.Auth.ClientToken, nil
+}
+
+func handleLoginErrors(err error) (string, error) {
+	if _, ok := err.(*json.SyntaxError); ok {
+		// some connection errors aren't properly caught, and the vault client tries to parse <nil>
+		return "", fmt.Errorf("error fetching secret from vault - check connection to the server")
+	}
+	return "", fmt.Errorf("error logging into vault: %s", err)
 }
 
 func (decrypter *VaultDecrypter) setTokenFetcher() error {


### PR DESCRIPTION
Our normal flow for fetching secrets is to attempt to read the KV v1 path and if that fails, we try the KV v2 path. 

Depending on how vault policies are configured, the error/warning response when you try to read a secret is different. We check if the response is "retryable" and if so, retry at the v2 path. This fixes a bug where we were failing to capture one of these retryable error responses from the v1 attempt, so we were prematurely returning the error without attempting the v2 path.

It also captures the error responses from both calls and logs them if a secret is still not found at the v2 path. This will hopefully prevent user confusion about attempting both v1 and v2 paths but returning only the error from the second/v2 attempt.