### PR TITLE
fix(vault): safer logic for when to retry secret fetch at KV v2 path

### DIFF
--- a/pkg/secrets/vault.go
+++ b/pkg/secrets/vault.go
@@ -291,25 +291,30 @@ func (decrypter *VaultDecrypter) newAPIClient() (*api.Client, error) {
 
 func (decrypter *VaultDecrypter) fetchSecret(client VaultClient) (string, error) {
 	path := decrypter.engine + "/" + decrypter.path
-	log.Debugf("attempting to read secret at KV v1 path: %s", path)
-	secretMapping, err := client.Read(path)
-	if err != nil {
-		if strings.Contains(err.Error(), "invalid character '<' looking for beginning of value") {
+	log.Infof("attempting to read secret at KV v1 path: %s", path)
+	secretMapping, v1err := client.Read(path)
+	if v1err != nil {
+		if strings.Contains(v1err.Error(), "invalid character '<' looking for beginning of value") {
 			// some connection errors aren't properly caught, and the vault client tries to parse <nil>
 			return "", fmt.Errorf("error fetching secret from vault - check connection to the server: %s",
 				decrypter.vaultConfig.Url)
 		}
-		return "", fmt.Errorf("error fetching secret from vault: %s", err)
 	}
 
-	if warnings := secretMapping.Warnings; containsRetryableWarning(warnings) {
+	var v2err error
+	decodedSecret, parseErr := decrypter.parseResults(secretMapping)
+	if decodedSecret == "" || parseErr != nil {
 		// try again using K/V v2 path
 		path = decrypter.engine + "/data/" + decrypter.path
-		log.Debugf("attempting to read secret at KV v2 path: %s", path)
-		secretMapping, err = client.Read(path)
-		if err != nil {
-			return "", fmt.Errorf("error fetching secret from vault: %s", err)
-		}
+		log.Infof("attempting to read secret at KV v2 path: %s", path)
+		secretMapping, v2err = client.Read(path)
+	}
+
+	if v2err != nil {
+		log.Infof("error reading secret at KV v1 path and KV v2 path")
+		log.Infof("KV v1 error: %s", v1err)
+		log.Infof("KV v2 error: %s", v2err)
+		return "", fmt.Errorf("error fetching secret from vault")
 	}
 
 	return decrypter.parseResults(secretMapping)
@@ -333,19 +338,6 @@ func (decrypter *VaultDecrypter) parseResults(secretMapping *api.Secret) (string
 	}
 	log.Debugf("successfully fetched secret")
 	return decrypted, nil
-}
-
-func containsRetryableWarning(warnings []string) bool {
-	if warnings == nil {
-		return false
-	}
-	for _, w := range warnings {
-		switch {
-		case strings.Contains(w, "Invalid path for a versioned K/V secrets engine"):
-			return true
-		}
-	}
-	return false
 }
 
 func DecodeVaultConfig(vaultYaml map[interface{}]interface{}) (*VaultConfig, error) {

--- a/pkg/secrets/vault_test.go
+++ b/pkg/secrets/vault_test.go
@@ -106,6 +106,27 @@ func TestVaultDecrypter_fetchSecret(t *testing.T) {
 				},
 			},
 		},
+		"v1 path permission denied, attempt v2 path": {
+			expectedSecret: "testvalue",
+			vc: &fakeVaultClient{
+				v1response: versionedResponse{
+					expectedPath: engine + "/" + path,
+					response:     nil,
+					err:          errors.New("permission denied"),
+				},
+				v2response: versionedResponse{
+					expectedPath: engine + "/data/" + path,
+					response: &api.Secret{
+						Data: map[string]interface{}{
+							"data": map[string]interface{}{
+								"key": "testvalue",
+							},
+						},
+					},
+					err: nil,
+				},
+			},
+		},
 		"v1 returns connection error": {
 			expectedError: "check connection to the server",
 			vc: &fakeVaultClient{
@@ -794,37 +815,4 @@ func TestParseVaultSecret(t *testing.T) {
 		})
 	}
 }
-
-//var userpassYaml = `
-//    secrets:
-//      vault:
-//        enabled: true
-//        url: https://vault.engineering.armory.io
-//        username: name
-//        password: pw
-//        userAuthPath: userpass
-//        authMethod: USERPASS
-//`
-//func Test_DecodeVaultConfig(t *testing.T) {
-//	cases := map[string]struct {
-//		yaml string
-//	}{
-//		"happy path": {
-//			yaml: userpassYaml,
-//		},
-//	}
-//	for testName, c := range cases {
-//		t.Run(testName, func(t *testing.T) {
-//
-//			any := map[interface{}]interface{}{}
-//			err := yaml.Unmarshal([]byte(c.yaml), &any)
-//			assert.Nil(t, err)
-//
-//			config, err := DecodeVaultConfig(any)
-//			assert.Nil(t, err)
-//			assert.Equal(t, "name", config.Username)
-//		})
-//	}
-//}
-
 


### PR DESCRIPTION
Our normal flow for fetching secrets is to attempt to read the KV v1 path and if that fails, we try the KV v2 path.

Depending on how vault policies are configured, the error/warning response when you try to read a secret is different. We used to check if the response is "retryable" and if so, retry at the v2 path. This fixes a bug where we were failing to capture one of these retryable error responses from the v1 attempt, so we were prematurely returning the error without attempting the v2 path. This uses safer logic that attempts to parse the results of the v1 path and if unsuccessful, tries the v2 path. That way, we aren't dependent on any specifics of the vault response.

It also captures the error responses from both calls and logs them if a secret is still not found at the v2 path. This will hopefully prevent user confusion about attempting both v1 and v2 paths but returning only the error from the second/v2 attempt.